### PR TITLE
security: remove hardcoded DB password, add .env to .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASS=
+DB_NAME=ecommerce

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.env
+.env.local

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ const port = 3000;
 app.use(express.json());
 
 const pool = mysql.createPool({
-    host: 'localhost',
-    user: 'root',
-    password: '4thIndu5tryR3v',
-    database: 'ecommerce'
+    host: process.env.DB_HOST || 'localhost',
+    user: process.env.DB_USER || 'root',
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME || 'ecommerce'
 });
 
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- Hardcoded MySQL password (`4thIndu5tryR3v`) removed from `index.js` — now reads from `process.env.DB_PASS`
- All DB connection values moved to environment variables (`DB_HOST`, `DB_USER`, `DB_PASS`, `DB_NAME`)
- Added `.env` and `.env.local` to `.gitignore`
- Added `.env.example` with required variable names

## Steps after merging
1. Create a `.env` file locally (gitignored): copy from `.env.example` and fill in your DB password
2. For any deployment, set `DB_PASS` as an environment variable